### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ Valipede
 Data validation for python.
 
 
-.. |PyPI| image:: https://pypip.in/version/valipede/badge.svg
+.. |PyPI| image:: https://img.shields.io/pypi/v/valipede.svg
    :target: https://pypi.python.org/pypi/valipede/
 
 .. |Build Status| image:: https://travis-ci.org/cooper-software/valipede.svg


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20valipede))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `valipede`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.